### PR TITLE
Fix typo in autobiller comment

### DIFF
--- a/jobs/autobiller.py
+++ b/jobs/autobiller.py
@@ -4,7 +4,7 @@ from billing.service import charge_due_subscriptions, send_precharge_notificatio
 
 log = logging.getLogger(__name__)
 
-# reccurent payments, checking subscriptions table if next_charge_at is already in past
+# recurrent payments, checking subscriptions table if next_charge_at is already in past
 async def autobiller_loop(interval_sec: int, notifier=None) -> None:
     while True:
         try:


### PR DESCRIPTION
## Summary
- correct a spelling mistake in the autobiller job comment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7ebf022108330a6b7227978a7587e